### PR TITLE
Changed image base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM governmentpaas/awscli:848d890e2aa7ffb049801c23dc85f981b49e491a
+FROM python:3.8.3-alpine3.12
 
-RUN apk add --no-cache jq py-pip
+RUN apk add --no-cache jq
 
 COPY assume-role /
 COPY requirements.txt /tmp


### PR DESCRIPTION
Basing the image from Python's Alpine image.  Resolves the requirement for `python3`.  We also no longer use anything provided by the previous `BASE`.