### PR TITLE
Add curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.8.3-alpine3.12
 
-RUN apk add --no-cache jq
+RUN apk add --no-cache jq curl
 
 COPY assume-role /
 COPY requirements.txt /tmp


### PR DESCRIPTION
`wget` doesn't work on Alpine when making a request via an HTTPS
proxy. See https://github.com/Yelp/dumb-init/issues/73 but the
workarounds there don't work either.